### PR TITLE
Fix states with delays only checking conditions once

### DIFF
--- a/Code/State.cs
+++ b/Code/State.cs
@@ -124,7 +124,7 @@ public sealed class State : IValid
 
 			if ( transition.Delay is { } delay )
 			{
-				if ( delay < prevTime || delay > nextTime )
+				if ( delay > prevTime || delay > nextTime )
 				{
 					continue;
 				}


### PR DESCRIPTION
This fixes this issue: https://github.com/Facepunch/sbox-libstates/issues/11
Before:

https://github.com/user-attachments/assets/bde3bef4-5d27-47fa-a375-cf75837a50a6

After:


https://github.com/user-attachments/assets/ff860d41-42fa-410c-a9cd-113a53db556a



